### PR TITLE
Fix parsing version components with double digits w/ 1+ `0`

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -68,7 +68,7 @@ exports.parse = function parse (input, state = { position: 0, partial: false }) 
     } else if (c >= '1' && c <= '9') {
       let j = 0
       do c = input[i + ++j]
-      while (c >= '1' && c <= '9')
+      while (c >= '0' && c <= '9')
 
       components.push(parseInt(input.substring(i, i + j)))
 

--- a/test.js
+++ b/test.js
@@ -7,7 +7,8 @@ test('parse version', (t) => {
   const cases = [
     ['0.0.0', new Version(0, 0, 0)],
     ['1.2.3', new Version(1, 2, 3)],
-    ['12.345.6789', new Version(12, 345, 6789)]
+    ['12.345.6789', new Version(12, 345, 6789)],
+    ['10.100.1000', new Version(10, 100, 1000)]
   ]
 
   for (const [input, expected] of cases) {
@@ -86,7 +87,8 @@ test('parse range', (t) => {
     ['<1.2.3', new Range([[new Comparator(LT, new Version(1, 2, 3))]])],
     ['<=1.2.3', new Range([[new Comparator(LTE, new Version(1, 2, 3))]])],
     ['>1.2.3', new Range([[new Comparator(GT, new Version(1, 2, 3))]])],
-    ['>=1.2.3', new Range([[new Comparator(GTE, new Version(1, 2, 3))]])]
+    ['>=1.2.3', new Range([[new Comparator(GTE, new Version(1, 2, 3))]])],
+    ['>1.10.0', new Range([[new Comparator(GT, new Version(1, 10, 0))]])]
   ]
 
   for (const [input, expected] of cases) {


### PR DESCRIPTION
`>=1.10.0` was the original problematic version string giving the following error:

```
Uncaught SemVerError: INVALID_VERSION: Unexpected token '0' in '>=1.10.0' at position 5, expected '.'
    at Version.parse (bare:/bare.bundle/node_modules/bare-semver/lib/version.js:61:12)
    at Range.parse (bare:/bare.bundle/node_modules/bare-semver/lib/range.js:92:49)
    at satisfies (bare:/bare.bundle/node_modules/bare-semver/index.js:10:48)
    at Function.validateEngines (bare:/bare.bundle/node_modules/bare-module-resolve/index.js:358:12)
    at exports.package (bare:/bare.bundle/node_modules/bare-module-resolve/index.js:185:33)
    at exports.package.next (<anonymous>)
    at exports.module (bare:/bare.bundle/node_modules/bare-module-resolve/index.js:98:26)
    at exports.module.next (<anonymous>)
    at [Symbol.iterator] (bare:/bare.bundle/node_modules/bare-module-resolve/index.js:22:28)
    at Generator.next (<anonymous>)
```

Figured out that it was a problem with the 'greedy' logic that aggregates the numerals to parse them as a whole. It was only checking 1–9 and didn't include 0.